### PR TITLE
Fix For Long Names Not Wrapping

### DIFF
--- a/TableCellResizeIssue.Core/TableCellResizeIssue.Core.csproj
+++ b/TableCellResizeIssue.Core/TableCellResizeIssue.Core.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Cirrious.CrossCore">
-        <HintPath>..\packages\MvvmCross.HotTuna.CrossCore.3.5.1\lib\portable-win+net45+wp8+win8+wpa81\Cirrious.CrossCore.dll</HintPath>
+      <HintPath>..\packages\MvvmCross.HotTuna.CrossCore.3.5.1\lib\portable-win+net45+wp8+win8+wpa81\Cirrious.CrossCore.dll</HintPath>
     </Reference>
     <Reference Include="Cirrious.MvvmCross">
       <HintPath>..\packages\MvvmCross.HotTuna.MvvmCrossLibraries.3.5.1\lib\portable-win+net45+wp8+win8+wpa81\Cirrious.MvvmCross.dll</HintPath>

--- a/TableCellResizeIssue.sln
+++ b/TableCellResizeIssue.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio 2012
 VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TableCellResizeIssue", "TableCellResizeIssue\TableCellResizeIssue.csproj", "{B5CD2F7E-3E13-4DF1-88F2-AEE27DAD898A}"

--- a/TableCellResizeIssue.userprefs
+++ b/TableCellResizeIssue.userprefs
@@ -1,0 +1,15 @@
+﻿<Properties StartupItem="TableCellResizeIssue/TableCellResizeIssue.csproj">
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug|iPhoneSimulator" PreferredExecutionTarget="MonoDevelop.IPhone.IPhoneSimulatorTarget.IPhone4s.8.3" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="TableCellResizeIssue/Controls/CustomCells/CustomerItemCell.cs">
+    <Files>
+      <File FileName="TableCellResizeIssue/Views/SearchView.cs" Line="141" Column="67" />
+      <File FileName="TableCellResizeIssue/Controls/CustomCells/CustomerItemTableViewSource.cs" Line="31" Column="67" />
+      <File FileName="TableCellResizeIssue/Controls/CustomCells/CustomerItemCell.cs" Line="197" Column="104" />
+      <File FileName="TableCellResizeIssue/Controls/CustomCells/AutoLayoutLabel.cs" Line="9" Column="30" />
+    </Files>
+  </MonoDevelop.Ide.Workbench>
+  <MonoDevelop.Ide.DebuggingService.Breakpoints>
+    <BreakpointStore />
+  </MonoDevelop.Ide.DebuggingService.Breakpoints>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+</Properties>

--- a/TableCellResizeIssue/Controls/CustomCells/AutoLayoutLabel.cs
+++ b/TableCellResizeIssue/Controls/CustomCells/AutoLayoutLabel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UIKit;
+using CoreGraphics;
+
+namespace TableCellResizeIssue.CustomCells
+{
+    public class AutoLayoutLabel : UILabel
+    {
+        public override CGRect Bounds
+        {
+            get
+            {
+                return base.Bounds;
+            }
+            set
+            {
+                base.Bounds = value;
+                if(this.Lines == 0 && Bounds.Size.Width != PreferredMaxLayoutWidth)
+                {
+                    PreferredMaxLayoutWidth = Bounds.Size.Width;
+                    SetNeedsUpdateConstraints();
+                }
+            }
+        }
+    }
+}
+

--- a/TableCellResizeIssue/Controls/CustomCells/CustomerItemCell.cs
+++ b/TableCellResizeIssue/Controls/CustomCells/CustomerItemCell.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 using Foundation;
 using UIKit;
+using TableCellResizeIssue.CustomCells;
 
 namespace TableCellResizeIssue.Controls.CustomCells
 {
@@ -193,33 +194,35 @@ namespace TableCellResizeIssue.Controls.CustomCells
             base.LayoutSubviews();
 
             // This weirdness is needed to push the label to wrap
-            this.customerNameLabel.PreferredMaxLayoutWidth = this.customerNameLabel.Frame.Size.Width;
+//            this.customerNameLabel.PreferredMaxLayoutWidth = this.customerNameLabel.Frame.Size.Width;
         }
 
-        public void UpdateCell(string artistName, string songTitle)
-        {
-            this.customerNameLabel.Text = artistName;
-            this.bornDataLabel.Text = songTitle;
-        }
-
-        public nfloat CalculateHeight(CGRect tableViewFrame)
-        {
-            this.Bounds = new CGRect(0, 0, tableViewFrame.Width, Bounds.Height);
-            this.SetNeedsLayout();
-            this.LayoutIfNeeded();
-
-            //This is where the magic happens
-            var size = ContentView.SystemLayoutSizeFittingSize(UILayoutFittingCompressedSize);
-
-            return size.Height + 1; //Add 1 since we are using cell separators.
-        }
+        //Not necessary anymore
+//        public void UpdateCell(string artistName, string songTitle)
+//        {
+//            this.customerNameLabel.Text = artistName;
+//            this.bornDataLabel.Text = songTitle;
+//        }
+//
+        //Not necessary anymore
+//        public nfloat CalculateHeight(CGRect tableViewFrame)
+//        {
+//            this.Bounds = new CGRect(0, 0, tableViewFrame.Width, Bounds.Height);
+//            this.SetNeedsLayout();
+//            this.LayoutIfNeeded();
+//
+//            //This is where the magic happens
+//            var size = ContentView.SystemLayoutSizeFittingSize(UILayoutFittingCompressedSize);
+//
+//            return size.Height + 1; //Add 1 since we are using cell separators.
+//        }
 
         /// <summary>
         /// Creates the layout.
         /// </summary>
         private void CreateView()
         {
-            this.customerNameLabel = new UILabel();
+            this.customerNameLabel = new AutoLayoutLabel();
             this.customerNameLabel.AccessibilityIdentifier = "CustomerItemCell_CustomerNameLabel";
             this.customerNameLabel.Font = UIFont.PreferredHeadline; //// CustomerBanner.GetBoldDerivative(UIFont.PreferredHeadline);
             this.customerNameLabel.Lines = 0;
@@ -287,21 +290,28 @@ namespace TableCellResizeIssue.Controls.CustomCells
                 this.bornLabel.AtBottomOf(this.ContentView, 5),
                 this.bornLabel.AtLeftOf(this.ContentView, 15),
                 this.bornDataLabel.WithSameTop(this.bornLabel),
-                this.bornDataLabel.ToRightOf(this.bornLabel, LabelDataMargin));
+                this.bornDataLabel.ToRightOf(this.bornLabel, LabelDataMargin),
+                this.bornDataLabel.AtBottomOf(this.ContentView, 5));
 
             this.ContentView.AddConstraints(
                 this.genderLabel.WithSameTop(this.bornLabel),
-                this.genderDataLabel.WithSameTop(this.bornLabel));
+                this.genderLabel.AtBottomOf(this.ContentView, 5),
+                this.genderDataLabel.WithSameTop(this.bornLabel),
+                this.genderDataLabel.AtBottomOf(this.ContentView, 5));
 
             this.ContentView.AddConstraints(
                 this.customerNumberLabel.WithSameTop(this.bornLabel),
-                this.customerNumberDataLabel.WithSameTop(this.bornLabel));
+                this.customerNumberLabel.AtBottomOf(this.ContentView, 5),
+                this.customerNumberDataLabel.WithSameTop(this.bornLabel),
+                this.customerNumberDataLabel.AtBottomOf(this.bornLabel, 5));
 
             this.ContentView.AddConstraints(
                                             this.genderLabel.ToRightOf(this.bornDataLabel, DataMargin),
                                             this.genderDataLabel.ToRightOf(this.genderLabel, LabelDataMargin),
                                             this.customerNumberLabel.ToRightOf(this.genderDataLabel, DataMargin),
                                             this.customerNumberDataLabel.ToRightOf(this.customerNumberLabel, LabelDataMargin));
+
+
             
             ////this.ContentView.TranslatesAutoresizingMaskIntoConstraints = false;
             this.SetNeedsUpdateConstraints();

--- a/TableCellResizeIssue/Controls/CustomCells/CustomerItemTableViewSource.cs
+++ b/TableCellResizeIssue/Controls/CustomCells/CustomerItemTableViewSource.cs
@@ -28,18 +28,19 @@ namespace TableCellResizeIssue.Controls.CustomCells
         {
         }
 
-        public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
-        {
-            var cell = tableView.DequeueReusableCell(new NSString("CustomerItemCell")) as CustomerItemCell;
-
-            var customer = GetItemAt(indexPath) as ItemViewModel<Customer>;
-            cell.UpdateCell(customer.Model.DisplayPersonName, customer.Model.DisplayDateOfBirth);
-
-            var height = cell.CalculateHeight(tableView.Frame);
-
-            ////Debug.Write("GetHeightForRow.Height: " + height);
-
-            return height;
-        }
+        //Since you're using iOS 8, this is not necessary anymore.
+//        public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
+//        {
+//            var cell = tableView.DequeueReusableCell(new NSString("CustomerItemCell")) as CustomerItemCell;
+//
+//            var customer = GetItemAt(indexPath) as ItemViewModel<Customer>;
+//            cell.UpdateCell(customer.Model.DisplayPersonName, customer.Model.DisplayDateOfBirth);
+//
+//            var height = cell.CalculateHeight(tableView.Frame);
+//
+//            Debug.WriteLine(String.Format("GetHeightForRow.Height ({0}): {1}", customer.Model.DisplayPersonName, height));
+//
+//            return height;
+//        }
     }
 }

--- a/TableCellResizeIssue/TableCellResizeIssue.csproj
+++ b/TableCellResizeIssue/TableCellResizeIssue.csproj
@@ -47,8 +47,8 @@
     <CodesignKey>iPhone Developer: Andrew Kirby %2824HAEWZF92%29</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignProvision>c6a6d2ad-cebc-4502-b81f-f638de1adb23</CodesignProvision>
-    <CodesignResourceRules />
-    <CodesignExtraArgs />
+    <CodesignExtraArgs>
+    </CodesignExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -100,6 +100,7 @@
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="packages.config" />
+    <Compile Include="Controls\CustomCells\AutoLayoutLabel.cs" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\Default-568h%402x.png" />
@@ -141,7 +142,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TableCellResizeIssue.Core\TableCellResizeIssue.Core.csproj">
-      <Project>{f2d725c5-3907-409b-bb10-381a043a38ca}</Project>
+      <Project>{F2D725C5-3907-409B-BB10-381A043A38CA}</Project>
       <Name>TableCellResizeIssue.Core</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
There wasn’t enough constraints defined for AutoLayout to determine the
height of the cell.  Added additional constraints so that auto layout
can calculate the height on its own.
